### PR TITLE
Fix variable name

### DIFF
--- a/cmsscraper.py
+++ b/cmsscraper.py
@@ -55,7 +55,7 @@ download_queue = []
 
 def main():
 
-    global token
+    global TOKEN
     global user_id
 
     # setup CLI args


### PR DESCRIPTION
`token`(argument name) seems to be global instead of `TOKEN`(global variable), leading to an error even when the correct token was used